### PR TITLE
NODEJS-2468: update arrowdb-node-sdk to add proxy support

### DIFF
--- a/lib/arrowdb.js
+++ b/lib/arrowdb.js
@@ -99,16 +99,21 @@ function ArrowDB(arrowDBAppKey, appOptions) {
 		throw new ArrowDBError(messages.ERR_WRONG_TYPE, {
 			typeName: 'ArrowDB app options'
 		});
-	} else if (!appOptions.apiEntryPoint) {
-		if (appOptions.apiEntryPoint && typeof appOptions.apiEntryPoint !== 'string') {
+	} else {
+		if(appOptions.apiEntryPoint && typeof appOptions.apiEntryPoint !== 'string') {
 			throw new ArrowDBError(messages.ERR_WRONG_TYPE, {
 				typeName: 'ArrowDB app options api entry point'
 			});
 		}
+
+		if(appOptions.proxy && typeof appOptions.proxy !== 'string') {
+			throw new ArrowDBError(messages.ERR_WRONG_TYPE, {
+				typeName: 'ArrowDB app options proxy'
+			});
+		}
+
 		this.appOptions = appOptions;
-		this.appOptions.apiEntryPoint = DEFAULT_API_ENTRY_POINT;
-	} else {
-		this.appOptions = appOptions;
+		this.appOptions.apiEntryPoint = this.appOptions.apiEntryPoint || DEFAULT_API_ENTRY_POINT;
 	}
 
 	// if autoSessionManagement isn't explicitly disabled, then force it on

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -132,6 +132,10 @@ function arrowDBRequest(apiEntryPoint, appOptions, httpMethod, cookieString, res
 		}
 	}
 
+	if (appOptions.proxy) {
+		requestParam.proxy = appOptions.proxy;
+	}
+
 	debug('request %j',requestParam);
 
 	request(requestParam, function (error, response, body) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arrowdb",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Appcelerator ArrowDB SDK for NodeJS",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
# Ticket
https://jira.appcelerator.org/browse/NODEJS-2468
# Description
updated arrowdb-node-sdk to add proxy support. Proxy should be a string including host, port and user info as necessary (e.g. “http://50.18.74.23:8080”) and should be when creating ArrowDB object the same way as apiEntryPoint.
# Test
Please verify that arrowdb-node-sdk works properly with a proxy set.