### PR TITLE
[API-1247] ArrowDB usersResendConfirmation method for Node.js SDK not working

### DIFF
--- a/lib/arrowdbObjects/users.js
+++ b/lib/arrowdbObjects/users.js
@@ -43,7 +43,7 @@ var arrowDBObject = {
 			},
 			resendConfirmation: {
 				httpMethod: 'GET',
-				restMethod: 'resend_confirmation.json'
+				restMethod: 'resend_confirmation'
 			},
 			search: {
 				httpMethod: 'GET'


### PR DESCRIPTION
https://jira.appcelerator.org/browse/API-1247

When creating a function for invoking an ArrowDB API,  the string `.json?key=` is used to form the URL. Therefore, `resend_confirmation.json` will be transformed into `v1/users/resend_confirmation.json.json?key=`, making a request using the api results in the `HTTP status code 406 Not Acceptable error`.

